### PR TITLE
Fixes for two problems found during spidering

### DIFF
--- a/devops/run-job.sh
+++ b/devops/run-job.sh
@@ -19,7 +19,9 @@
 #   secrets/datastore-writer.json
 
 
-DOCKERIMAGE="quay.io/netzbegruenung/green-spider:dev"
+DOCKERIMAGE="quay.io/netzbegruenung/green-spider:latest"
+
+RESULTS_ENTITY_KIND="spider-results"
 
 API_TOKEN_SECRET="secrets/hetzner-api-token.sh"
 test -f $API_TOKEN_SECRET || { echo >&2 "File $API_TOKEN_SECRET does not exist."; exit 1; }
@@ -161,7 +163,7 @@ else
     $DOCKERIMAGE \
     --credentials-path /secrets/datastore-writer.json \
     --loglevel info \
-    spider --kind spider-results-dev
+    spider --kind $RESULTS_ENTITY_KIND
 
 fi
 

--- a/rating/no_script_errors.py
+++ b/rating/no_script_errors.py
@@ -21,14 +21,16 @@ class Rater(AbstractRater):
         found_pageloads = 0
         found_errors = 0
         for url in self.check_results['load_in_browser']:
-            if self.check_results['load_in_browser'][url]['logs'] == []:
+            if (self.check_results['load_in_browser'][url]['logs'] == [] or 
+                self.check_results['load_in_browser'][url]['logs'] is None):
                 found_pageloads += 1
                 continue
             
             # scan log entries for script errors
-            for entry in self.check_results['load_in_browser'][url]['logs']:
-                if entry['source'] == 'javascript':
-                    found_errors += 1
+            if self.check_results['load_in_browser'][url]['logs'] is not None:
+                for entry in self.check_results['load_in_browser'][url]['logs']:
+                    if entry['source'] == 'javascript':
+                        found_errors += 1
 
         if found_pageloads > 0 and found_errors == 0:
             value = True


### PR DESCRIPTION
1. Change the database (entity kind) name to use `spider-results` instead of `spider-results-dev` again
2. Fix a usage of `self.check_results['load_in_browser'][url]['logs']` in the `no_script_errors` rater