### PR TITLE
Rate use of Titillium as an alternative to Arvo

### DIFF
--- a/rating/use_specific_fonts.py
+++ b/rating/use_specific_fonts.py
@@ -26,7 +26,7 @@ class Rater(AbstractRater):
                 continue
             
             fonts = " ".join(self.check_results['load_in_browser'][url]['font_families'])
-            if 'arvo' in fonts:
+            if 'arvo' in fonts or 'titillium' in fonts:
                 urls_with_font += 1
         
         if urls_with_font > 0 and urls_without_font == 0:


### PR DESCRIPTION
Die Grüne Jugend hat eigene Corporate-Design-Vorgaben, die nicht die Schriftart Arvo, sondern `Titillium` erfordern. Mit diesem PR wird das Verwenden von Titillium genau so gewertet wie das Verwenden von Arvo.

Das beinhaltet keine Unterscheidung, um welche Art von Organisation es sich bei der Website handelt.