### PR TITLE
Fix link raters (social media links, contact link)

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -56,6 +56,15 @@ def perform_checks(input_url):
     for check_name, check in check_modules:
         checker = check.Checker(config=config,
                                 previous_results=results)
+
+        # see if dependencies are met
+        dependencies = checker.depends_on_results()
+        if dependencies != []:
+            for dep in dependencies:
+                if (dep not in results or results[dep] is None or results[dep] == {} or results[dep] == []):
+                    logging.debug("Skipping check %s as dependency %s is not met" % (check_name, dep))
+                    continue
+
         result = checker.run()
         results[check_name] = result
 

--- a/checks/abstract_checker.py
+++ b/checks/abstract_checker.py
@@ -10,10 +10,17 @@ class AbstractChecker(object):
         # Key is the name of the checker that has generated the result.
         self._previous_results = previous_results
 
+    def depends_on_results(self):
+        """
+        Should return  the name(s) of checks this one depends on.
+        Empty list means this check has no prerequisites.
+        """
+        return []
+
     def run(self):
         """Executes the check routine, returns result dict"""
         raise NotImplementedError()
-
+    
     @property
     def config(self):
         return self._config

--- a/checks/generator.py
+++ b/checks/generator.py
@@ -15,6 +15,9 @@ class Checker(AbstractChecker):
     def __init__(self, config, previous_results=None):
         super().__init__(config, previous_results)
     
+    def depends_on_results(self):
+        return ['page_content', 'html_head', 'dns_resolution']
+
     def run(self):
         assert 'page_content' in self.previous_results
         assert 'html_head' in self.previous_results

--- a/checks/hyperlinks.py
+++ b/checks/hyperlinks.py
@@ -11,7 +11,10 @@ from checks.abstract_checker import AbstractChecker
 class Checker(AbstractChecker):
     def __init__(self, config, previous_results=None):
         super().__init__(config, previous_results)
-    
+
+    def depends_on_results(self):
+        return ['page_content']
+
     def run(self):
         assert 'page_content' in self.previous_results
         

--- a/checks/url_reachability.py
+++ b/checks/url_reachability.py
@@ -23,6 +23,9 @@ class Checker(AbstractChecker):
     def __init__(self, config, previous_results=None):
         super().__init__(config, previous_results)
     
+    def depends_on_results(self):
+        return ['dns_resolution']
+
     def run(self):
         headers = {
             "User-Agent": self.config.user_agent

--- a/rating/contact_link.py
+++ b/rating/contact_link.py
@@ -31,7 +31,7 @@ class Rater(AbstractRater):
                     # make sure we only count 1 for this url
                     break
 
-        if urls_with_contact_link == urls:
+        if urls > 0 and urls_with_contact_link == urls:
             score = self.max_score
             value = True
 

--- a/rating/social_media_links.py
+++ b/rating/social_media_links.py
@@ -52,7 +52,7 @@ class Rater(AbstractRater):
                     # make sure we only count 1 for this url
                     break
 
-        if urls_with_social_media_links == urls:
+        if urls > 0 and urls_with_social_media_links == urls:
             score = self.max_score
             value = True
 


### PR DESCRIPTION
Dies behebt zwei Fehler, bei denen Links bewertet wurden, auch wenn keine URLs ausgewertet wurden (wie es bei nicht erreichbaren Sites der Fall ist).