### PR TITLE
Extend CMS detection for Urwahl3000 theme

### DIFF
--- a/checks/generator.py
+++ b/checks/generator.py
@@ -3,8 +3,6 @@ Checks the 'generator' meta tag and page content properties
 to detect well-known content management systems, themes etc.
 """
 
-import logging
-
 from checks.abstract_checker import AbstractChecker
 
 class Checker(AbstractChecker):


### PR DESCRIPTION
This should enable detecting the generator in a page like https://grüne-porta-westfalica.de/, where the theme name is not present in the footer, but in many src/href attribute values.