### PR TITLE
Prüfe DNS auf IPv6 AAAA Record

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/v3.8/main" >> /etc/apk/repositories
     apk update && \
     apk --no-cache add chromium chromium-chromedriver python3-dev build-base git py3-lxml libxml2 libxml2-dev libxslt libxslt-dev libffi-dev openssl-dev && \
     pip3 install --upgrade pip && \
-    pip3 install selenium==3.8.0 GitPython PyYAML beautifulsoup4==4.6.0 html-similarity==0.3.2 httpretty==0.9.4 feedparser==5.2.1 pyopenssl==18.0.0 requests==2.18.4 responses==0.9.0 smmap2==2.0.3 urllib3==1.22 google-cloud-datastore==1.7.0 tenacity==5.0.2 && \
+    pip3 install dnspython==1.16.0 selenium==3.8.0 GitPython PyYAML beautifulsoup4==4.6.0 html-similarity==0.3.2 httpretty==0.9.4 feedparser==5.2.1 pyopenssl==18.0.0 requests==2.18.4 responses==0.9.0 smmap2==2.0.3 urllib3==1.22 google-cloud-datastore==1.7.0 tenacity==5.0.2 && \
     apk del python3-dev build-base
 
 ADD cli.py /

--- a/checks/dns_resolution_test.py
+++ b/checks/dns_resolution_test.py
@@ -1,4 +1,6 @@
 import unittest
+import logging
+import sys
 from pprint import pprint
 
 from checks import dns_resolution
@@ -6,7 +8,7 @@ from checks.config import Config
 
 class TestDNSResolution(unittest.TestCase):
 
-    def test_google(self):
+    def runTest(self):
         """Resolves www.google.com"""
         url = 'https://www.google.com/'
         config = Config(urls=[url])
@@ -15,9 +17,13 @@ class TestDNSResolution(unittest.TestCase):
 
         self.assertIn(url, result)
         self.assertEqual(result[url]['hostname'], 'www.google.com')
-        self.assertTrue(result[url], 'resolvable')
+        self.assertTrue(result[url], 'resolvable_ipv4')
+        self.assertTrue(result[url], 'resolvable_ipv6')
         self.assertIsInstance(result[url]['ipv4_addresses'], list)
         self.assertNotEqual(result[url]['ipv4_addresses'], [])
 
 if __name__ == '__main__':
-    unittest.main()
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+    unittest.TextTestRunner().run(TestDNSResolution())
+
+    #unittest.main()

--- a/rating/resolvable.py
+++ b/rating/resolvable.py
@@ -20,7 +20,7 @@ class Rater(AbstractRater):
 
         count = 0
         for url in self.check_results['dns_resolution']:
-            if self.check_results['dns_resolution'][url]['resolvable']:
+            if self.check_results['dns_resolution'][url]['resolvable_ipv4']:
                 count += 1
         
         if count > 0:


### PR DESCRIPTION
In Richtung https://github.com/netzbegruenung/green-spider/issues/123

Dieser PR erweitert den DNS-Test um das Abfragen eines AAAA-Records zu Ermittlung von IPv6-Adressen zum Hostnamen und speichert die Antwort.

Die Frage, ob ein Hostname grundsätzlich als auflösbar gilt, wird weiterhin von der IPv4-Adresse abhängig gemacht, denn in der Praxis dürfte aktuell die IPv6-Adresse alleine nicht genügen.