### PR TITLE
Add a check for green power

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -21,6 +21,7 @@ from checks import load_in_browser
 from checks import page_content
 from checks import url_canonicalization
 from checks import url_reachability
+from checks import green_power
 
 from checks.config import Config
 
@@ -50,6 +51,7 @@ def perform_checks(input_url):
         ('load_favicons', load_favicons),
         ('load_feeds', load_feeds),
         ('load_in_browser', load_in_browser),
+        ('green_power', green_power),
     ]
 
     results = {}

--- a/checks/green_power.py
+++ b/checks/green_power.py
@@ -1,0 +1,56 @@
+"""
+This check looks up the domain of site against the Green Web Foundation API,
+to confirm that sites in the green party, run on green power, rather
+than fossil fuels.
+"""
+
+import logging
+
+import requests
+from urllib.parse import urlparse
+
+from checks.abstract_checker import AbstractChecker
+
+logger = logging.getLogger(__name__)
+
+
+class Checker(AbstractChecker):
+
+    API_ENDPOINT = "http://api.thegreenwebfoundation.org/greencheck/"
+
+    def __init__(self, config, previous_results=None):
+        super().__init__(config, previous_results)
+
+    def run(self):
+        """Executes the check routine, returns result dict"""
+
+        results = {}
+
+        urls = list(self.config.urls)
+        for url in urls:
+            hostname = urlparse(url).hostname
+            results[url] = self.check_for_green_power(hostname)
+
+        return results
+
+    def check_for_green_power(self, url):
+        """
+        Checks the url passed in agains the Green web Foundation API
+        to see if the domain known to be running on green power.
+        """
+        # use the "big tarp" to catch the error, but don't crash the program
+        # returning false because we didn't come back with any  evidence that
+        # the site uses green power
+        # more on the big tarp:
+        # https://www.loggly.com/blog/exceptional-logging-of-exceptions-in-python/
+        check_url = f"{self.API_ENDPOINT}{url}"
+
+        try:
+            result = requests.get(check_url)
+            return result.json().get('green')
+        except Exception:
+            logger.exception("Requesting data from the API failed")
+
+            return False
+
+

--- a/checks/green_power_test.py
+++ b/checks/green_power_test.py
@@ -14,17 +14,9 @@ class TestGreenPower(unittest.TestCase):
         result = checker.run()
         self.assertEqual(result['https://google.com/'], True)
 
-
-        self.assertEqual(1, 1)
-
     def test_is_not_green(self):
         """Check that we get a grey result for grey powered site"""
         config = Config(urls=['http://www.kochind.com/'])
         checker = green_power.Checker(config=config)
         result = checker.run()
         self.assertEqual(result['http://www.kochind.com/'], False)
-
-
-
-
-

--- a/checks/green_power_test.py
+++ b/checks/green_power_test.py
@@ -1,0 +1,31 @@
+import unittest
+
+from checks import green_power
+from checks.config import Config
+
+class TestGreenPower(unittest.TestCase):
+
+    def test_is_green(self):
+        """Checks that we get a green result for green powered site"""
+        # google is green, Koch Industries. predictably is not
+        # TODO mock the result, so we don't need to hit a live API
+        config = Config(urls=['https://google.com/'])
+        checker = green_power.Checker(config=config)
+        result = checker.run()
+        urls_after = checker.config.urls
+        print(urls_after)
+
+        self.assertEqual(1, 1)
+
+    def test_is_not_green(self):
+        """Checks that we get a grey result for grey powered site"""
+        config = Config(urls=['http://www.kochind.com/'])
+        checker = green_power.Checker(config=config)
+        result = checker.run()
+        urls_after = checker.config.urls
+        print(urls_after)
+
+
+
+
+

--- a/checks/green_power_test.py
+++ b/checks/green_power_test.py
@@ -6,24 +6,23 @@ from checks.config import Config
 class TestGreenPower(unittest.TestCase):
 
     def test_is_green(self):
-        """Checks that we get a green result for green powered site"""
+        """Check that we get a green result for green powered site"""
         # google is green, Koch Industries. predictably is not
         # TODO mock the result, so we don't need to hit a live API
         config = Config(urls=['https://google.com/'])
         checker = green_power.Checker(config=config)
         result = checker.run()
-        urls_after = checker.config.urls
-        print(urls_after)
+        self.assertEqual(result['https://google.com/'], True)
+
 
         self.assertEqual(1, 1)
 
     def test_is_not_green(self):
-        """Checks that we get a grey result for grey powered site"""
+        """Check that we get a grey result for grey powered site"""
         config = Config(urls=['http://www.kochind.com/'])
         checker = green_power.Checker(config=config)
         result = checker.run()
-        urls_after = checker.config.urls
-        print(urls_after)
+        self.assertEqual(result['http://www.kochind.com/'], False)
 
 
 


### PR DESCRIPTION
I'm at the Green party hackcamp in Essen, and it seemed consistent to make it possible to check that Green party websites run on green power.

I've added this check, but I might need pointers to check the rest of the repos.

- [ ] add the Check for Green Power
- [ ] add the Rater for Green Power
- [ ] revisit the api testing code to consider using mocks response instead hitting the live API
- [ ] work out which other repos need changes for this to be visible
- [ ] document how deploys of new changes work