### PR TITLE
Upgrade PyOpenSSL, remove unit tests using TLS 1.0 and 1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.15.6
 
 WORKDIR /workdir
 

--- a/checks/certificate_test.py
+++ b/checks/certificate_test.py
@@ -26,26 +26,6 @@ class TestCertificateChecker(unittest.TestCase):
         self.assertIsNone(result[url]['exception'])
         self.assertEqual(result[url]['issuer']['O'], 'DigiCert Inc')
 
-    def test_tls_v_1_0(self):
-        """Load a certificate for a TLS v1.0 server"""
-        url = 'https://tls-v1-0.badssl.com:1010/'
-        config = Config(urls=[url])
-        checker = certificate.Checker(config=config, previous_results={})
-        result = checker.run()
-        self.assertIn(url, result)
-        self.assertIsNone(result[url]['exception'])
-        self.assertEqual(result[url]['subject']['CN'], '*.badssl.com')
-
-    def test_tls_v_1_1(self):
-        """Load a certificate for a TLS v1.1 server"""
-        url = 'https://tls-v1-1.badssl.com:1011/'
-        config = Config(urls=[url])
-        checker = certificate.Checker(config=config, previous_results={})
-        result = checker.run()
-        self.assertIn(url, result)
-        self.assertIsNone(result[url]['exception'])
-        self.assertEqual(result[url]['subject']['CN'], '*.badssl.com')
-
     def test_tls_v_1_2(self):
         """Load a certificate for a TLS v1.2 server"""
         url = 'https://tls-v1-2.badssl.com:1012/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ protobuf==3.19.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21
-pyOpenSSL==20.0.1
+pyOpenSSL==22.1.0
 pytz==2021.3
 PyYAML==5.4.1
 redis==3.5.3


### PR DESCRIPTION
Ziel: unit tests sollen wieder funktioinieren.

Davor sind die Tests mit diesem Fehler fehlgeschlagen:

```
======================================================================
ERROR: checks (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: checks
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/loader.py", line 470, in _find_test_path
    package = self._get_module_from_name(name)
  File "/usr/lib/python3.10/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/workdir/checks/__init__.py", line 8, in <module>
    from checks import certificate
  File "/workdir/checks/certificate.py", line 12, in <module>
    from OpenSSL import crypto
  File "/usr/lib/python3.10/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1556, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1577, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

Um das zu beheben, musste wohl PyOpenSSL von 20.x auf 22.x aktualisiert werden. Dies unterstützt wohl kein TLS 1.0 und 1.1 mehr.