### PR TITLE
Damit der Spider endlich auch auf einer Hetzner-VM durchläuft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 
-ENV CHROMIUM_VERSION=123.0.6312.86-r0
+ENV CHROMIUM_VERSION=124.0.6367.78-r0
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.19/community" >> /etc/apk/repositories && \
     apk --update --no-cache add ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.19@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 
+# Find an eligible version at https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/
 ENV CHROMIUM_VERSION=124.0.6367.78-r0
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.19/community" >> /etc/apk/repositories && \

--- a/checks/certificate_test.py
+++ b/checks/certificate_test.py
@@ -14,7 +14,7 @@ class TestCertificateChecker(unittest.TestCase):
         result = checker.run()
         self.assertIn(url, result)
         self.assertIsNone(result[url]['exception'])
-        self.assertEqual(result[url]['issuer']['O'], 'Google Trust Services LLC')
+        self.assertEqual(result[url]['issuer']['O'], 'Google Trust Services')
 
     def test_kaarst(self):
         """Real-workd example"""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,13 @@
-version: "2"
 services:
 
   redis:
-    image: redis:5-alpine
-    command: redis-server --save "" --appendonly no
+    image: redis:6-alpine
+    command: redis-server
     volumes:
-      - ${PWD}/volumes/redis-data:/data
+      - ${PWD}/volumes/redis-data:/data:rw
     restart: unless-stopped
-    networks:
-      - internal_network
-      - external_network
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
   # manager fills the job queue with spider jobs.
   manager:
@@ -26,9 +22,6 @@ services:
     volumes:
       - ${PWD}/secrets:/secrets
       - ${PWD}/cache/green-directory:/workdir/cache/green-directory
-    networks:
-      - internal_network
-      - external_network
     depends_on:
       - redis
 
@@ -37,16 +30,7 @@ services:
   #   image: eoranged/rq-dashboard:v0.6.1
   #   environment:
   #     RQ_DASHBOARD_REDIS_URL: redis://redis:6379/0
-  #   networks:
-  #     - internal_network
-  #     - external_network
   #   ports:
   #     - "9181:9181"
   #   depends_on:
   #     - redis
-
-networks:
-  internal_network:
-    internal: true
-  external_network:
-    internal: false


### PR DESCRIPTION
Bisher brach der Spider immer ab, weil irgendwann die Job Queue leer war. Das lag letztlich wohl daran, dass der redis Service für die Welt zugänglich und schreibbar war.

Hier werden noch ein paar andere Dinge verbessert.